### PR TITLE
 Allow @odata to json keys in higher odata 4.0

### DIFF
--- a/src/Transaction/MetadataContainer.php
+++ b/src/Transaction/MetadataContainer.php
@@ -110,7 +110,7 @@ class MetadataContainer implements ArrayAccess
         $result = [];
 
         foreach ($properties as $key => $value) {
-            if (version_compare('4.0', $requestedODataVersion, '=')) {
+            if (version_compare($requestedODataVersion, '4.0', '>=')) {
                 $result[$this->prefix.'@odata.'.$key] = $value;
             } else {
                 $result[$this->prefix.'@'.$key] = $value;


### PR DESCRIPTION
Hi,
I am currently using odata version 4.014.01 together with the devextreme tools.

I have detected that the "count" parameter did not arrive as @odata.count, which is what the devextreme tools need to work on v4.

This change has solved the problem for me. I share it in case someone can use it.

It is my first PR, please tell me if there is something in which I have failed.

Thanks for the tool.