### PR TITLE
Pgsql patch

### DIFF
--- a/src/Drivers/SQL/SQLLimits.php
+++ b/src/Drivers/SQL/SQLLimits.php
@@ -22,7 +22,13 @@ trait SQLLimits
             return '';
         }
 
+
         $limits = ' LIMIT ?,?';
+
+        switch ($this->getDriver()) {
+            case 'pgsql':
+                $limits = ' LIMIT ? OFFSET ?';
+        }
 
         $this->addParameter($this->getSkip()->getValue());
         $this->addParameter($this->getTop()->hasValue() ? $this->getTop()->getValue() : PHP_INT_MAX);

--- a/src/Drivers/SQL/SQLLimits.php
+++ b/src/Drivers/SQL/SQLLimits.php
@@ -22,16 +22,10 @@ trait SQLLimits
             return '';
         }
 
+        $limits = ' LIMIT ? OFFSET ?';
 
-        $limits = ' LIMIT ?,?';
-
-        switch ($this->getDriver()) {
-            case 'pgsql':
-                $limits = ' LIMIT ? OFFSET ?';
-        }
-
-        $this->addParameter($this->getSkip()->getValue());
         $this->addParameter($this->getTop()->hasValue() ? $this->getTop()->getValue() : PHP_INT_MAX);
+        $this->addParameter($this->getSkip()->getValue());
 
         return $limits;
     }

--- a/src/Drivers/SQL/SQLOrderBy.php
+++ b/src/Drivers/SQL/SQLOrderBy.php
@@ -36,7 +36,7 @@ trait SQLOrderBy
                 );
             }
 
-            return "$literal $direction";
+            return $this->quote($literal)." $direction";
         }, $orderby->getSortOrders()));
 
         return ' ORDER BY '.$ob;


### PR DESCRIPTION
1. - Fix unquoted strings when generating the ORDER BY string
2. - Fixes how limits are handled in SQL for PostgreSQL