### PR TITLE
Add missing extension dependencies to `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,15 @@
         "sebastian/diff": "^4.0|^5.0",
         "m6web/redis-mock": "^5.5",
         "predis/predis": "^2.1.2",
-        "mongodb/mongodb": "^1.11"
+        "mongodb/mongodb": "^1.11",
+        "ext-pdo_sqlsrv": "*",
+        "ext-odbc": "*",
+        "ext-pdo_odbc": "*",
+        "ext-pdo_pgsql": "*",
+        "ext-pdo_mysql": "*",
+        "ext-mongodb": "*",
+        "ext-redis": "*",
+        "ext-pdo_sqlite": "*"
     },
     "suggest": {
         "league/csv": "To use the CSV entity set",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7802a1c11e2e10ceb19ecea0f06af714",
+    "content-hash": "7d102006acab4a82f106328663977196",
     "packages": [
         {
             "name": "brick/math",
@@ -10173,6 +10173,15 @@
         "ext-dom": "*",
         "ext-pdo": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {
+        "ext-pdo_sqlsrv": "*",
+        "ext-odbc": "*",
+        "ext-pdo_odbc": "*",
+        "ext-pdo_pgsql": "*",
+        "ext-pdo_mysql": "*",
+        "ext-mongodb": "*",
+        "ext-redis": "*",
+        "ext-pdo_sqlite": "*"
+    },
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Based on [`.github/workflows/tests.yml`](https://github.com/flat3/lodata/blob/5.x/.github/workflows/tests.yml) (and a whole lot of failing tests) these extensions are required to run the tests, but they're not declared in `composer.json` right now.

This means composer won't scream when the extensions aren't (properly) installed, which leads to a confusing failure of all 2.000+ tests :)