### PR TITLE
Set Docker services' `restart` to `on-failure`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   mysql_db:
     image: "mysql:latest"
-    restart: always
+    restart: on-failure
     expose:
       - 3306
     ports:
@@ -20,7 +20,7 @@ services:
 
   postgres_db:
     image: "postgres:latest"
-    restart: always
+    restart: on-failure
     expose:
       - 5432
     ports:
@@ -38,7 +38,7 @@ services:
 
   sqlsrv_db:
     image: "mcr.microsoft.com/mssql/server"
-    restart: always
+    restart: on-failure
     expose:
       - 1433
     ports:
@@ -54,7 +54,7 @@ services:
 
   mongo_db:
     image: "mongo"
-    restart: always
+    restart: on-failure
     expose:
       - 27017
     ports:


### PR DESCRIPTION
Services with a `restart` of `always` also automatically (re)start when Docker Desktop boots, including if that's on system startup.
As much as I love this project, I don't work on it every day, so this becomes a bit of a problem with my system's finite amount of memory 😅