### PR TITLE
Limit `binary` attribute for txt files to snapshots

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,4 +9,4 @@ Dockerfile export-ignore
 docker-compose.yml export-ignore
 phpstan.neon export-ignore
 phpunit.xml export-ignore
-*.txt binary
+tests/__snapshots__/**/*.txt binary


### PR DESCRIPTION
eca25b9 added the `binary` attribute to all txt files, which fixes a bunch of tests on Windows (#747).
Most Windows programs handle LF-line endings just fine, but unfortunately not all, so to avoid ✨shenanigans✨ it's good practice to limit the binary attribute to the files that actually need it.

Keep up the great work!