### PR TITLE
Clarify Laravel/PHP version support matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,18 +14,28 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - php: "8.3"
-            laravel: 10
-          - php: "8.2"
-            laravel: 10
-          - php: "8.1"
-            laravel: 9
-          - php: "8.0"
-            laravel: 8
-          - php: "7.4"
-            laravel: 8
-          - php: "7.3"
-            laravel: 8
+          - laravel: 10
+            php: "8.3"
+          - laravel: 10
+            php: "8.2"
+          - laravel: 10
+            php: "8.1"
+
+          - laravel: 9
+            php: "8.2"
+          - laravel: 9
+            php: "8.1"
+          - laravel: 9
+            php: "8.0"
+
+          - laravel: 8
+            php: "8.1"
+          - laravel: 8
+            php: "8.0"
+          - laravel: 8
+            php: "7.4"
+          - laravel: 8
+            php: "7.3"
     name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
     steps:
       - uses: actions/checkout@v3

--- a/doc/introduction/requirements.md
+++ b/doc/introduction/requirements.md
@@ -1,8 +1,8 @@
 # Requirements
 
-Lodata works with Laravel 8 (PHP 7.3 - 8.1) and Laravel 9 (PHP 8.0 - 8.1).
-
-* PHP: `^7.3|^7.4|^8.0`
-* Laravel: `^8.0|^9.0`
+Lodata v5 works with:
+- Laravel 8 (PHP 7.3 - 8.1)
+- Laravel 9 (PHP 8.0 - 8.2)
+- Laravel 10 (PHP 8.1 - 8.3)
 
 To use any of the PDO database connectors you must have the correct PHP extensions installed.


### PR DESCRIPTION
I added a couple missing Laravel/PHP version combinations [supported by Laravel](https://laravel.com/docs/10.x/releases#support-policy) to the CI and updated the requirements page of the docs accordingly.

I switched the `laravel` and `php` keys around in the CI config to make it easier to read quickly, in principle the list of PHP versions is based on the version of Laravel :)
I looked into using a "regular" matrix configuration to avoid forgetting versions, but as you probably already discovered there doesn't seem to be a convenient way to do this for our usecase :(