### PR TITLE
Avoid exponents when printing float values

### DIFF
--- a/src/Helper/JSON.php
+++ b/src/Helper/JSON.php
@@ -31,6 +31,9 @@ final class JSON
      */
     public static function encode($value): string
     {
+        if (is_float($value)) {
+            return rtrim(sprintf('%.10f', $value), '0.') ?: '0';
+        }
         return json_encode($value, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
     }
 }

--- a/src/Helper/JSON.php
+++ b/src/Helper/JSON.php
@@ -32,7 +32,12 @@ final class JSON
     public static function encode($value): string
     {
         if (is_float($value)) {
-            return rtrim(sprintf('%.10f', $value), '0.') ?: '0';
+            $v = sprintf('%.10f', $value) ?: '0';
+            if (false !== strpos($v, '.')) {
+                $v = rtrim($v, '0');
+                $v = rtrim($v, '.');
+            }
+            return $v;
         }
         return json_encode($value, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
     }


### PR DESCRIPTION
Some MSOffice products don't work well with exponents in JSON values.
This happens when a very small values is being printed.

This PR suggests we use `sprintf` instead of `json_encode` when printing a `float` value.