### PR TITLE
Fix - `getRelated()` on null for relationship discovery

### DIFF
--- a/src/Drivers/EloquentEntitySet.php
+++ b/src/Drivers/EloquentEntitySet.php
@@ -514,6 +514,13 @@ class EloquentEntitySet extends EntitySet implements CountInterface, CreateInter
             /** @var Relation $relation */
             $relation = $model->$method();
 
+            if (!$relation instanceof Relation) {
+                throw new ConfigurationException(
+                    'invalid_relationship',
+                    'The method could not return a valid relationship'
+                );
+            }
+
             $relatedModel = get_class($relation->getRelated());
 
             $right = Lodata::getResources()->sliceByClass(self::class)->find(function ($set) use ($relatedModel) {


### PR DESCRIPTION
Namaskar,

This PR addresses an issue by introducing an additional `instanceof` check for the `$relation` to see if it's a valid relationship, in the EloquentEntitySet driver. If not, bail early.

https://github.com/flat3/lodata/blob/1c3b45a06da9fceb8698a1925f63eb12ebb01c01/src/Drivers/EloquentEntitySet.php#L517

I'm not sure as to why even in case of a null exception, the `get_class` is not bailing, but doing a check to bail seems to work.

Here's a stack trace where I was able to encounter this issue: https://flareapp.io/share/J7oxAYx5

Here's the offending model snippet, the `...` denotes parts that have nothing to do with the bug:
```
...

use Flat3\Lodata\Attributes\LodataRelationship;
use Illuminate\Database\Eloquent\Factories\HasFactory;

class Companies extends Model
{
    use HasFactory;
    use InputScopeTrait;

    protected $table = 'companies';

    protected $fillable = [
        ...
        'domain_id',
        'organization_id',
    ];

    protected $guarded = ['id'];

    public $timestamps = true;

    /**
     * Define the relationship where each row belongs to one domain.
     *
     * @return \Illuminate\Database\Eloquent\Relations\hasOne
     */
    #[LodataRelationship]
    public function domain()
    {
        return $this->hasOne(Domains::class, 'id', 'domain_id');
    }

    /**
     * Define the relationship where each row belongs to one organization.
     *
     * @return \Illuminate\Database\Eloquent\Relations\hasOne
     */
    #[LodataRelationship]
    public function organization()
    {
        return $this->hasOne(Organizations::class, 'id', 'organization_id');
    }

    ...

    /**
     * Define the relationship where each row can have multiple payment information.
     *
     * @return \Illuminate\Database\Eloquent\Relations\hasMany
     */
    #[LodataRelationship]
    public function paymentInformation()
    {
        return $this->hasMany(PaymentInformation::class, 'owner_id', 'id')
            ->where('owner_type', 'Organization')
            ->where('domain_id', $this->domain_id)
            ->where('organization_id', $this->organization_id);
    }
}
```

`OdataCompanies` Class:
```
...
namespace App\Providers\Odata;

use Illuminate\Support\ServiceProvider;
use App\Models\Account\Companies;

/**
 * Lodata Service Provider
 * @package App\Providers
 */
class ODataCompanies extends ServiceProvider
{
    public function boot()
    {
        if (app()->runningInConsole() || app()->environment('testing')) {
            return;
        }

        \Lodata::discover(Companies::class);
    }
}
```
Essentially loaded into as a provider.

Additional information:

* PHP 8.2.15 (built: Jan 20 2024 14:17:05) (NTS)
* Laravel Framework 10.43.0
* MySQL Community version 8@latest

Note it's essentially the stock Laravel 10.x sail docker image.