### PR TITLE
Accept API requests with lowercase GUID Keys

### DIFF
--- a/src/PathSegment/Key.php
+++ b/src/PathSegment/Key.php
@@ -43,7 +43,7 @@ class Key implements PipeInterface
         $keyValue->setProperty($keyProperty);
         $keyValue->setValue($keyProperty->getType()->instance($currentSegment));
 
-        if ((string) $keyValue->getPrimitiveValue() !== $currentSegment) {
+        if (!$keyValue->getPrimitive()->matches($currentSegment)) {
             throw new PathNotHandledException();
         }
 

--- a/src/Primitive.php
+++ b/src/Primitive.php
@@ -175,7 +175,7 @@ abstract class Primitive implements ResourceInterface, ContextInterface, Identif
      * @param  mixed  $value
      * @return bool
      */
-    public function matches(mixed $value): bool
+    public function matches($value): bool
     {
         if ($value instanceof self) {
             $value = $value->get();

--- a/src/Primitive.php
+++ b/src/Primitive.php
@@ -170,6 +170,24 @@ abstract class Primitive implements ResourceInterface, ContextInterface, Identif
         return $value instanceof $this && $value->get() === $this->get();
     }
 
+    /**
+     * Return whether the provided value is a representation of this one
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function matches(mixed $value): bool
+    {
+        if ($value instanceof self) {
+            $value = $value->get();
+        }
+
+        if (is_scalar($value) || is_null($value) || $value instanceof \Stringable) {
+            return (string) $this->get() === (string) $value;
+        }
+
+        return false;
+    }
+
     public static function pipe(
         Transaction $transaction,
         string $currentSegment,

--- a/src/Type/Guid.php
+++ b/src/Type/Guid.php
@@ -21,6 +21,19 @@ class Guid extends Primitive
     /** @var ?string $value */
     protected $value;
 
+    public function matches($value): bool
+    {
+        if ($value instanceof self) {
+            $value = $value->get();
+        }
+
+        if (is_scalar($value) || is_null($value) || $value instanceof \Stringable) {
+            return (string) $this->get() === strtoupper((string) $value);
+        }
+
+        return false;
+    }
+
     public function toUrl(): string
     {
         if (null === $this->value) {

--- a/tests/Queries/GuidTest.php
+++ b/tests/Queries/GuidTest.php
@@ -48,5 +48,10 @@ class GuidTest extends TestCase
             (new Request)
                 ->path('/examples(00000000-0000-0000-0000-0012EA25EEFB)')
         );
+
+        $this->assertJsonResponseSnapshot(
+            (new Request)
+                ->path('/examples(00000000-0000-0000-0000-0012ea25eefb)')
+        );
     }
 }

--- a/tests/__snapshots__/Queries/GuidTest__test_filter_guid__5.json
+++ b/tests/__snapshots__/Queries/GuidTest__test_filter_guid__5.json
@@ -1,0 +1,4 @@
+{
+    "@context": "http://localhost/odata/$metadata#examples/$entity",
+    "id": "00000000-0000-0000-0000-0012EA25EEFB"
+}


### PR DESCRIPTION
As per definition UUIDs are case-insensitive. Yet the `Key` Pipe verifies UUID values not in their byte representation, but in their case-sensitive string representation.

The `Primitive::matches` helper method can be handy to address similar quirks with other types.