### PR TITLE
Update PHPdoc & allow `immutable` annotation via Attributes on Eloquent Model 

### DIFF
--- a/src/Attributes/LodataProperty.php
+++ b/src/Attributes/LodataProperty.php
@@ -6,6 +6,7 @@ namespace Flat3\Lodata\Attributes;
 
 use Flat3\Lodata\Annotation\Core\V1\Computed;
 use Flat3\Lodata\Annotation\Core\V1\Description;
+use Flat3\Lodata\Annotation\Core\V1\Immutable;
 use Flat3\Lodata\DeclaredProperty;
 use Flat3\Lodata\EntitySet;
 use Flat3\Lodata\Property;
@@ -18,6 +19,7 @@ abstract class LodataProperty
     protected ?string $source = null;
     protected bool $key = false;
     protected bool $computed = false;
+    protected bool $immutable = false;
     protected bool $nullable = true;
     protected ?int $maxLength = null;
     protected ?int $precision = null;
@@ -38,13 +40,15 @@ abstract class LodataProperty
         $scale = null,
         $alternativeKey = false,
         $searchable = false,
-        $filterable = true
+        $filterable = true,
+        ?bool $immutable = false
     ) {
         $this->name = $name;
         $this->description = $description;
         $this->source = $source;
         $this->key = $key;
         $this->computed = $computed;
+        $this->immutable = $immutable;
         $this->nullable = $nullable;
         $this->maxLength = $maxLength;
         $this->precision = $precision;
@@ -82,6 +86,11 @@ abstract class LodataProperty
     public function isComputed(): bool
     {
         return $this->computed;
+    }
+
+    public function isImmutable(): bool
+    {
+        return $this->immutable;
     }
 
     public function isNullable(): bool
@@ -156,6 +165,10 @@ abstract class LodataProperty
 
         if ($this->isComputed()) {
             $property->addAnnotation(new Computed);
+        }
+
+        if ($this->isImmutable()) {
+            $property->addAnnotation(new Immutable);
         }
 
         if ($this->hasMaxLength()) {

--- a/src/Drivers/EloquentEntitySet.php
+++ b/src/Drivers/EloquentEntitySet.php
@@ -151,9 +151,7 @@ class EloquentEntitySet extends EntitySet implements CountInterface, CreateInter
      */
     public function getTable(): string
     {
-        $model = $this->getModel();
-
-        return $model->getTable();
+        return $this->getModel()->getTable();
     }
 
     /**
@@ -168,7 +166,7 @@ class EloquentEntitySet extends EntitySet implements CountInterface, CreateInter
     /**
      * Read an Eloquent model
      * @param  PropertyValue  $key  Model key
-     * @return Entity|null Entity
+     * @return Entity Entity
      */
     public function read(PropertyValue $key): Entity
     {
@@ -257,6 +255,10 @@ class EloquentEntitySet extends EntitySet implements CountInterface, CreateInter
     public function delete(PropertyValue $key): void
     {
         $model = $this->getModelByKey($key);
+
+        if (null === $model) {
+            throw new NotFoundException('entity_not_found', 'Entity not found');
+        }
 
         try {
             $model->delete();

--- a/src/GeneratedProperty.php
+++ b/src/GeneratedProperty.php
@@ -16,7 +16,7 @@ abstract class GeneratedProperty extends Property
     /**
      * Generate the property value for this property on the provided entity
      * @param  ComplexValue  $value  Entity this property is generated on
-     * @return PropertyValue
+     * @return Primitive|scalar|null
      */
     abstract public function invoke(ComplexValue $value);
 


### PR DESCRIPTION
When overloading some classes I need to suppress psalm errors for invalid return types, when they are actually correct:

## Changes

- `GeneratedProperty::invoke` does expect a `Primitive` (but it is able to convert scalar types itself)
- `EloquentEntitySet::read` should correctly implement and comply with the `ReadInterface` it implements
- Added an argument to annotate properties as `immutable` 
  eg: `#[LodataString(name: 'Type', source: 'type', immutable: true)]`

 ---

## Comments
I'm still looking into the immutable aspect of the library because I feel `Immutable`, `Computed` and `ComputedDefaultValue` are implemented too loosely ([vocabulary here](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md)):

I've defined a property as computed and the OpenAPI specification looks good, the property is not defined for Create- or Update operations. But it is accepted and passed on as in the arguments nonetheless - so in my case the user is able to manipulate computed attributes like the `updated` date, by just providing a value in their PATCH request 🤔 

