### PR TITLE
[WIP] Fix for HasManyThrough

### DIFF
--- a/src/Drivers/EloquentEntitySet.php
+++ b/src/Drivers/EloquentEntitySet.php
@@ -543,12 +543,12 @@ class EloquentEntitySet extends EntitySet implements CountInterface, CreateInter
 
             $navigationProperty->setNullable($nullable);
 
-            if ($relation instanceof HasOneOrMany || $relation instanceof BelongsTo) {
+            if ($relation instanceof HasOneOrMany || $relation instanceof BelongsTo || $relation instanceof HasManyThrough) {
                 $localProperty = null;
                 $foreignProperty = null;
-
                 switch (true) {
                     case ($relation instanceof HasOneOrMany) || ($relation instanceof HasManyThrough):
+
                         $localProperty = $this->getPropertyBySourceName($relation->getLocalKeyName());
                         $foreignProperty = $right->getPropertyBySourceName($relation->getForeignKeyName());
                         break;

--- a/src/Drivers/EloquentEntitySet.php
+++ b/src/Drivers/EloquentEntitySet.php
@@ -548,7 +548,7 @@ class EloquentEntitySet extends EntitySet implements CountInterface, CreateInter
                 $foreignProperty = null;
 
                 switch (true) {
-                    case $relation instanceof HasOneOrMany:
+                    case ($relation instanceof HasOneOrMany) || ($relation instanceof HasManyThrough):
                         $localProperty = $this->getPropertyBySourceName($relation->getLocalKeyName());
                         $foreignProperty = $right->getPropertyBySourceName($relation->getForeignKeyName());
                         break;


### PR DESCRIPTION
**Edit:** On second hand; This is not the currect solution. However, filtering on expanded HasManyThrough is still not working.

HasManyThrough relations were not filterable. To recreate this issue you can use the following database from the Laravel documentation:
```
projects
    id - integer
    name - string
 
environments
    id - integer
    project_id - integer
    name - string
 
deployments
    id - integer
    environment_id - integer
    commit_hash - string
```

When recreated the above, the following query returns all projects instead of a any with a commit hash.

`http://127.0.0.1:8000/odata/Projects?$expand=Deployments($filter=commit_hash eq 'XXX')&$filter=Deployments/any(s:s/commit_hash eq 'XXX')`