### PR TITLE
Ignoreable routes

### DIFF
--- a/src/Facades/Lodata.php
+++ b/src/Facades/Lodata.php
@@ -55,6 +55,8 @@ use Illuminate\Support\Facades\Facade;
  * @method static string getOdcUrl(Identifier|string $set) Get the Office Data Connection URL of the provided entity set
  * @method static string getPbidsUrl() Get the PowerBI discovery URL of this service
  * @method static string getOpenApiUrl() Get the OpenAPI specification document URL of this service
+ * @method static void ignoreRoutes() Disable the automatic registration of the base routes
+ * @method static bool shouldIgnoreRoutes() Determine if routes should be ignored
  * @package Flat3\Lodata\Facades
  */
 class Lodata extends Facade

--- a/src/Model.php
+++ b/src/Model.php
@@ -45,6 +45,12 @@ class Model implements AnnotationInterface
      */
     protected $entityContainer;
 
+    /**
+     * Determine if routes should be ignored
+     * @var true
+     */
+    protected $registersRoutes;
+
     public function __construct()
     {
         $this->model = new ObjectArray();
@@ -371,5 +377,23 @@ class Model implements AnnotationInterface
     public function getOpenApiUrl(): string
     {
         return ServiceProvider::endpoint().'openapi.json';
+    }
+
+    /**
+     * Disable the automatic registration of the base routes
+     * @return void
+     */
+    public function ignoreRoutes(): void
+    {
+        $this->registersRoutes = false;
+    }
+
+    /**
+     * Determine if routes should be ignored
+     * @return bool True if routes should be ignored, false otherwise.
+     */
+    public function shouldIgnoreRoutes(): bool
+    {
+        return $this->registersRoutes;
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -81,6 +81,9 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         Route::get("{$route}/_lodata/odata.pbids", [PBIDS::class, 'get']);
         Route::get("{$route}/_lodata/{identifier}.odc", [ODCFF::class, 'get']);
         Route::resource("{$route}/_lodata/monitor", Monitor::class);
-        Route::any("{$route}{path}", [OData::class, 'handle'])->where('path', '(.*)')->middleware($middleware);
+
+        if (Lodata::shouldIgnoreRoutes()) {
+            Route::any("{$route}{path}", [OData::class, 'handle'])->where('path', '(.*)')->middleware($middleware);
+        }
     }
 }


### PR DESCRIPTION
In my implementation, I only require the use of OData with GET requests. However, Lodata registers a Route::any by default, which intercepts all HTTP methods. 
This causes conflicts when trying to define standard routes for other methods (`e.g., POST, PUT, DELETE`) since they are routed to Lodata due to the shared prefix between the API and Lodata routes.

To resolve this, I've introduced a getter and setter in the model that determines whether a route should be registered. 
This property defaults to `true`, providing flexibility in controlling which routes are handled by Lodata and enabling the ability to override the base route.

Example Usage:
-

**In AppServiceProvider:** 
Add the following line inside the boot() method to stop Lodata from automatically registering routes:
> Lodata::ignoreRoutes();

**In api.php:**
Define a specific GET route for OData requests:
> Route::get('{path}', [OData::class, 'handle'])->where('path', '(.*)');
