### PR TITLE
Added constraint support for CollectionEntitySet

### DIFF
--- a/src/NavigationProperty.php
+++ b/src/NavigationProperty.php
@@ -183,7 +183,12 @@ class NavigationProperty extends Property
                 $foreignKey = $targetConstraint->getReferencedProperty()->getName();
                 $localKeyName = $value->getEntitySet()->getType()->getKey();
                 $localKey = $value->getPropertyValues()->get($localKeyName)->getValue();
-                $expansionTransaction->getFilter()->setValue($foreignKey . ' eq ' . $localKey);
+                $constraintInjection = $foreignKey . " eq '" . $localKey . "'";
+
+                $filterData = $expansionTransaction->getFilter()->getValue();
+                $filterData = $filterData ? "(" . $filterData . ") and " . $constraintInjection : $constraintInjection;
+
+                $expansionTransaction->getFilter()->setValue($filterData);
             }
         }
 


### PR DESCRIPTION
This commit answers a specific requirement we had where we needed custom CollectionEntitySets to follow relationship constraints.
Found out constraints where only working with SqlEntitySet, so I updated the code by altering the Transaction's filter with a manual constraint injection.

This is probably not the best way to implement it, but this could initiate a discussion on this feature here.

Have a good one!