### PR TITLE
Don't include the etag header on an entity when using , in line with dataverse

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -314,7 +314,9 @@ class Entity extends ComplexValue
 
         $response = $transaction->getResponse();
         $transaction->assertIfMatchHeader($this->getETag());
-        $transaction->setETagHeader($this->getETag());
+        if (!$transaction->getExpand()->hasValue()) {
+            $transaction->setETagHeader($this->getETag());
+        }
 
         return $response->setResourceCallback($this, function () use ($transaction) {
             $this->emitJson($transaction);

--- a/tests/Navigation/Navigation.php
+++ b/tests/Navigation/Navigation.php
@@ -251,11 +251,12 @@ abstract class Navigation extends TestCase
 
     public function test_expand_entity()
     {
-        $this->assertJsonResponseSnapshot(
-            (new Request)
-                ->path($this->airportEntitySetPath.'/1')
-                ->expand('flights')
-        );
+        $this
+            ->assertJsonResponseSnapshot(
+                (new Request)
+                    ->path($this->airportEntitySetPath.'/1')
+                    ->expand('flights'))
+            ->assertHeaderMissing('etag');
     }
 
     public function test_expand_hasone_entity()


### PR DESCRIPTION
Just for context, we've experienced an issue where out of date cached data is being used by our OData API client because of the ETag header being returned on the first request: The client is `$expand`ing a related entity, but because the ETag doesn't account for this, it remains the same, and so a 304 status is returned and the client uses the old version.

I had a look into this, and whilst the offical OData standards doc isn't specific about this, the Microsoft Dataverse docs suggest that the ETag header should be excluded in this case (https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/perform-conditional-operations-using-web-api#query-must-not-include-expand)