### PR TITLE
fix DBAL 4 issues

### DIFF
--- a/src/Drivers/SQL/SQLSchema.php
+++ b/src/Drivers/SQL/SQLSchema.php
@@ -99,17 +99,23 @@ trait SQLSchema
 
             if ($column->getDefault()) {
                 $property->addAnnotation(new ComputedDefaultValue);
+                $default = $column->getDefault();
 
                 switch (true) {
-                    case $column->getDefault() === $platform->getCurrentTimestampSQL():
+                    // DBAL 4.x returns DefaultExpression objects instead of strings
+                    case !is_string($default):
                         $property->setDefaultValue([Carbon::class, 'now']);
                         break;
 
-                    case $platform->getReservedKeywordsList()->isKeyword($column->getDefault()):
+                    case $default === $platform->getCurrentTimestampSQL():
+                        $property->setDefaultValue([Carbon::class, 'now']);
+                        break;
+
+                    case $platform->getReservedKeywordsList()->isKeyword($default):
                         break;
 
                     default:
-                        $property->setDefaultValue($column->getDefault());
+                        $property->setDefaultValue($default);
                         break;
                 }
             }


### PR DESCRIPTION
Full disclaimer: Code was generated by AI. I did test it on a real project myself though.


# Fix DBAL 4.x compatibility: handle `DefaultExpression` in `SQLSchema`

## Problem

In Doctrine DBAL 4.x, `Column::getDefault()` can return a `DefaultExpression` object (e.g. `DefaultExpression\CurrentTimestamp`) instead of a plain string. This causes a `TypeError` in `SQLSchema::discoverProperties()` when the return value is passed to `KeywordList::isKeyword()`, which expects a string argument:

```
TypeError: Doctrine\DBAL\Platforms\Keywords\KeywordList::isKeyword():
Argument #1 ($word) must be of type string,
Doctrine\DBAL\Schema\DefaultExpression\CurrentTimestamp given
```

This crashes discovery for any model with a column that has a `CURRENT_TIMESTAMP` (or similar) default value.

## Fix

Added a type check before processing column defaults. Non-string defaults (i.e. `DefaultExpression` objects) are treated as computed timestamp defaults, matching the existing behavior for `CURRENT_TIMESTAMP` string defaults:

```php
$default = $column->getDefault();

switch (true) {
    // DBAL 4.x returns DefaultExpression objects instead of strings
    case !is_string($default):
        $property->setDefaultValue([Carbon::class, 'now']);
        break;

    case $default === $platform->getCurrentTimestampSQL():
        // ...
}
```

## Impact

- **Backward compatible** — DBAL 3.x always returns strings, so the `!is_string()` branch is never hit
- **Single file change** — `src/Drivers/SQL/SQLSchema.php`
- **No new dependencies**
