### PR TITLE
Fix: validate $filter before streaming response (return 400 not malformed 200)

### DIFF
--- a/src/EntitySet.php
+++ b/src/EntitySet.php
@@ -266,6 +266,7 @@ abstract class EntitySet implements EntityTypeInterface, ReferenceInterface, Ide
         }
 
         $this->assertValidOrderBy();
+        $this->assertValidFilter();
 
         return $transaction->getResponse()->setResourceCallback($this, function () use ($transaction, $context) {
             $context = $context ?: $this;
@@ -1129,6 +1130,25 @@ abstract class EntitySet implements EntityTypeInterface, ReferenceInterface, Ide
                 sprintf('The orderby parameter specified properties (%s) that did not exist', join(',', $diff))
             );
         }
+    }
+
+    /**
+     * Assert that the $filter expression is syntactically valid and references only known properties.
+     * This runs BEFORE the streaming response begins so that an invalid filter yields HTTP 400
+     * rather than a malformed mid-stream error fragment.
+     * @return void
+     */
+    protected function assertValidFilter(): void
+    {
+        $filter = $this->getFilter();
+
+        if (!$filter->hasValue()) {
+            return;
+        }
+
+        $parser = $this->getFilterParser();
+        $parser->pushEntitySet($this);
+        $parser->generateTree($filter->getExpression());
     }
 
     /**


### PR DESCRIPTION
## Summary

When `$filter` references an unknown property (e.g. `$filter=BadField eq 'value'`), Lodata starts streaming the HTTP 200 response before evaluating the filter. The filter parse error then occurs mid-stream, injecting an error JSON fragment into the already-started response body. The client receives malformed output that is neither a valid OData error response (HTTP 400) nor valid JSON.

Per the OData specification, an invalid `$filter` should return HTTP 400 Bad Request before any response body is sent.

## Changes

Added `assertValidFilter()` in `EntitySet::get()`, called immediately after the existing `assertValidOrderBy()` and before the `StreamedResponse` callback is registered. This eagerly parses the filter expression using the entity set's own filter parser, causing any `ParserException` (which extends `BadRequestException`) to be thrown before streaming begins.

## How it works

The call chain for a GET request is:
1. `get()` — validates orderby, **now validates filter**, then registers the streaming callback
2. Streaming callback → `emitJson()` → `query()` → `generateWhere()` → `generateTree()`

With this fix, an invalid `$filter` throws at step 1, before `StreamedResponse::sendContent()` begins writing. The exception propagates through Laravel's normal error handling and produces a clean HTTP 400.

## Impact

- Invalid `$filter` now returns proper HTTP 400 instead of malformed HTTP 200
- Mirrors the existing `assertValidOrderBy()` pattern exactly
- Valid requests parse the filter tree twice (once for validation, once in `generateWhere()`) — negligible cost for correctness
- No new exception types; `ParserException` already maps to HTTP 400

## Testing

- PHP syntax check passes
- Pattern follows existing `assertValidOrderBy()` precedent