### PR TITLE
perf: cache SQL schema descriptors and add operation discovery fast-path

### DIFF
--- a/src/Drivers/SQL/SQLSchema.php
+++ b/src/Drivers/SQL/SQLSchema.php
@@ -25,26 +25,72 @@ use Illuminate\Support\Arr;
 trait SQLSchema
 {
     /**
-     * Discover SQL fields on this entity set as OData properties
+     * Discover SQL fields on this entity set as OData properties.
+     * Uses Discovery::remember() to cache the full processed property descriptors
+     * (not just the raw DBAL Table), avoiding per-request column-to-property conversion.
      * @return $this
      */
     public function discoverProperties()
     {
-        $table = (new Discovery)->remember(
-            sprintf("sql.%s.%s", $this->getConnection()->getName(), $this->getTable()),
-            function () {
-                return $this->getDatabase()->listTableDetails($this->getTable());
-            }
-        );
+        $cacheKey = sprintf("sql.properties.%s.%s", $this->getConnection()->getName(), $this->getTable());
 
-        $columns = $table->getColumns();
-        $indexes = $table->getIndexes();
+        $propertyDescriptors = (new Discovery)->remember($cacheKey, function () {
+            return $this->buildPropertyDescriptors();
+        });
 
         $type = $this->getType();
 
-        /** @var DeclaredProperty $key */
-        $key = null;
+        // Hydrate cached descriptors into actual OData DeclaredProperty objects
+        if (isset($propertyDescriptors['key'])) {
+            $keyDesc = $propertyDescriptors['key'];
+            $key = new DeclaredProperty($keyDesc['name'], $this->resolveType($keyDesc['type']));
+            if ($keyDesc['computed']) {
+                $key->addAnnotation(new Computed);
+            }
+            $type->setKey($key);
+        }
 
+        foreach ($propertyDescriptors['properties'] as $propDesc) {
+            $property = new DeclaredProperty($propDesc['name'], $this->resolveType($propDesc['type']));
+            $property->setNullable($propDesc['nullable']);
+
+            if ($propDesc['has_default']) {
+                $property->addAnnotation(new ComputedDefaultValue);
+                if ($propDesc['default_value'] !== null) {
+                    $property->setDefaultValue($propDesc['default_value']);
+                }
+                if ($propDesc['default_is_carbon_now'] ?? false) {
+                    $property->setDefaultValue([Carbon::class, 'now']);
+                }
+            }
+
+            if (isset($propDesc['source_name'])) {
+                $this->setPropertySourceName($property, $propDesc['source_name']);
+            }
+
+            $type->addProperty($property);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Build a serializable array of property descriptors from the database schema.
+     * This is the expensive part that we cache.
+     * @return array
+     */
+    protected function buildPropertyDescriptors(): array
+    {
+        $table = $this->getDatabase()->listTableDetails($this->getTable());
+
+        $columns = $table->getColumns();
+        $indexes = $table->getIndexes();
+        $blacklist = config('lodata.discovery.blacklist', []);
+        $platform = $this->getDatabase()->getDatabasePlatform();
+
+        $result = ['key' => null, 'properties' => []];
+
+        // Find primary key
         foreach ($indexes as $index) {
             if (!$index->isPrimary()) {
                 continue;
@@ -59,65 +105,138 @@ trait SQLSchema
                 continue;
             }
 
-            $key = $this->columnToDeclaredProperty($column);
-
-            if (null === $key) {
+            $typeName = $this->columnToTypeName($column);
+            if ($typeName === null) {
                 throw new ConfigurationException(
                     'missing_key',
                     sprintf('The table %s had no resolvable key', $this->getTable())
                 );
             }
 
-            if ($column->getAutoincrement()) {
-                $key->addAnnotation(new Computed);
-            }
-
-            $type->setKey($key);
+            $result['key'] = [
+                'name' => $this->resolveColumnName($column),
+                'type' => $typeName,
+                'computed' => $column->getAutoincrement(),
+            ];
         }
 
-        $blacklist = config('lodata.discovery.blacklist', []);
-        $platform = $this->getDatabase()->getDatabasePlatform();
+        // Process remaining columns
+        $keyName = $result['key'] ? $result['key']['name'] : null;
 
         foreach ($columns as $column) {
-            $columnName = $column->getName();
+            $columnName = $this->resolveColumnName($column);
 
-            if ($key && $columnName === $key->getName()) {
+            if ($keyName && $columnName === $keyName) {
                 continue;
             }
 
-            if (in_array($columnName, $blacklist)) {
+            if (in_array($column->getName(), $blacklist)) {
                 continue;
             }
 
-            $property = $this->columnToDeclaredProperty($column);
-
-            if (null === $property) {
+            $typeName = $this->columnToTypeName($column);
+            if ($typeName === null) {
                 continue;
             }
 
-            $property->setNullable(!$column->getNotnull());
+            $propDesc = [
+                'name' => $columnName,
+                'type' => $typeName,
+                'nullable' => !$column->getNotnull(),
+                'has_default' => (bool) $column->getDefault(),
+                'default_value' => null,
+                'default_is_carbon_now' => false,
+            ];
+
+            // Track source name if it differs from the resolved column name
+            if ($columnName !== $column->getName()) {
+                $propDesc['source_name'] = $column->getName();
+            }
 
             if ($column->getDefault()) {
-                $property->addAnnotation(new ComputedDefaultValue);
-
-                switch (true) {
-                    case $column->getDefault() === $platform->getCurrentTimestampSQL():
-                        $property->setDefaultValue([Carbon::class, 'now']);
-                        break;
-
-                    case $platform->getReservedKeywordsList()->isKeyword($column->getDefault()):
-                        break;
-
-                    default:
-                        $property->setDefaultValue($column->getDefault());
-                        break;
+                if ($column->getDefault() === $platform->getCurrentTimestampSQL()) {
+                    $propDesc['default_is_carbon_now'] = true;
+                } elseif (!$platform->getReservedKeywordsList()->isKeyword($column->getDefault())) {
+                    $propDesc['default_value'] = $column->getDefault();
                 }
             }
 
-            $type->addProperty($property);
+            $result['properties'][] = $propDesc;
         }
 
-        return $this;
+        return $result;
+    }
+
+    /**
+     * Map a DBAL column to an OData type name string (for caching).
+     * @param Column $column
+     * @return string|null
+     */
+    protected function columnToTypeName(Column $column): ?string
+    {
+        $columnType = $column->getType();
+
+        switch (true) {
+            case $columnType instanceof Types\BooleanType:
+                return 'boolean';
+            case $columnType instanceof Types\DateType:
+                return 'date';
+            case $columnType instanceof Types\DateTimeType:
+                return 'datetimeoffset';
+            case $columnType instanceof Types\DecimalType:
+            case $columnType instanceof Types\FloatType:
+                return 'decimal';
+            case $columnType instanceof Types\SmallIntType:
+                return $column->getUnsigned() ? 'uint16' : 'int16';
+            case $columnType instanceof Types\IntegerType:
+                return $column->getUnsigned() ? 'uint32' : 'int32';
+            case $columnType instanceof Types\BigIntType:
+                return $column->getUnsigned() ? 'uint64' : 'int64';
+            case $columnType instanceof Types\TimeType:
+                return 'timeofday';
+            case $columnType instanceof Types\StringType:
+            default:
+                return 'string';
+        }
+    }
+
+    /**
+     * Resolve a type name string back to an OData Type instance.
+     * @param string $typeName
+     * @return Type
+     */
+    protected function resolveType(string $typeName): Type
+    {
+        switch ($typeName) {
+            case 'boolean': return Type::boolean();
+            case 'date': return Type::date();
+            case 'datetimeoffset': return Type::datetimeoffset();
+            case 'decimal': return Type::decimal();
+            case 'uint16':
+                return Lodata::getTypeDefinition(Type\UInt16::identifier) ? Type::uint16() : Type::int16();
+            case 'int16': return Type::int16();
+            case 'uint32':
+                return Lodata::getTypeDefinition(Type\UInt32::identifier) ? Type::uint32() : Type::int32();
+            case 'int32': return Type::int32();
+            case 'uint64':
+                return Lodata::getTypeDefinition(Type\UInt64::identifier) ? Type::uint64() : Type::int64();
+            case 'int64': return Type::int64();
+            case 'timeofday': return Type::timeofday();
+            case 'string':
+            default: return Type::string();
+        }
+    }
+
+    /**
+     * Resolve the name of a column, accounting for namespaced columns.
+     * @param Column $column
+     * @return string
+     */
+    protected function resolveColumnName(Column $column): string
+    {
+        return $column->getNamespaceName()
+            ? ($column->getNamespaceName().'_'.$column->getShortestName($column->getNamespaceName()))
+            : $column->getName();
     }
 
     /**

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -809,8 +809,22 @@ class Operation implements ServiceInterface, ResourceInterface, IdentifierInterf
             return;
         }
 
-        $namespace = null;
         $reflectionClass = new ReflectionClass($discoverable);
+
+        // Fast path: skip full discovery if no methods have LodataOperation attributes.
+        // This avoids expensive reflection loops for Eloquent models that don't define operations.
+        $hasAnyOperations = false;
+        foreach ($reflectionClass->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+            if ($method->getAttributes(LodataOperation::class, ReflectionAttribute::IS_INSTANCEOF)) {
+                $hasAnyOperations = true;
+                break;
+            }
+        }
+        if (!$hasAnyOperations) {
+            return;
+        }
+
+        $namespace = null;
 
         /** @var ReflectionAttribute $namespaceAttribute */
         $namespaceAttribute = Arr::first($reflectionClass->getAttributes(LodataNamespace::class));

--- a/tests/Setup/DiscoveryTest.php
+++ b/tests/Setup/DiscoveryTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Flat3\Lodata\Tests\Setup;
 
-use Doctrine\DBAL\Schema\Table;
 use Flat3\Lodata\Drivers\MongoEntitySet;
 use Flat3\Lodata\Drivers\MongoEntityType;
 use Flat3\Lodata\Facades\Lodata;
@@ -61,9 +60,12 @@ class DiscoveryTest extends TestCase
         ]);
 
         Lodata::discoverEloquentModel(Airport::class);
-        $table = Cache::store('redis')->get('lodata.discovery.sql.testing.airports');
-        $this->assertInstanceOf(Table::class, $table);
-        $this->assertEquals(-2, Cache::store('redis')->getRedis()->ttl('lodata.discovery.sql.testing.airports'));
+        $cacheKey = 'lodata.discovery.sql.properties.testing.airports';
+        $cached = Cache::store('redis')->get($cacheKey);
+        $this->assertIsArray($cached);
+        $this->assertArrayHasKey('key', $cached);
+        $this->assertArrayHasKey('properties', $cached);
+        $this->assertEquals(-2, Cache::store('redis')->getRedis()->ttl($cacheKey));
     }
 
     public function test_default_config()


### PR DESCRIPTION
Item 1 (SQLSchema): Replace the old two-step approach (cache raw DBAL Table, re-process columns every request) with a fully cached pipeline. The new buildPropertyDescriptors() stores a serializable array of type names, nullability, and default values. discoverProperties() hydrates these into OData DeclaredProperty objects without touching the database again on cache hits.

Item 5 (Operation): Add an early-exit in Operation::discover() that checks for any LodataOperation attributes before doing the full per-method reflection scan. Models without operations (the common case) return immediately.