### PR TITLE
perf: cache SQL schema descriptors and add operation discovery fast-path

### DIFF
--- a/src/Operation.php
+++ b/src/Operation.php
@@ -809,8 +809,22 @@ class Operation implements ServiceInterface, ResourceInterface, IdentifierInterf
             return;
         }
 
-        $namespace = null;
         $reflectionClass = new ReflectionClass($discoverable);
+
+        // Fast path: skip full discovery if no methods have LodataOperation attributes.
+        // This avoids expensive reflection loops for Eloquent models that don't define operations.
+        $hasAnyOperations = false;
+        foreach ($reflectionClass->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+            if ($method->getAttributes(LodataOperation::class, ReflectionAttribute::IS_INSTANCEOF)) {
+                $hasAnyOperations = true;
+                break;
+            }
+        }
+        if (!$hasAnyOperations) {
+            return;
+        }
+        
+        $namespace = null;
 
         /** @var ReflectionAttribute $namespaceAttribute */
         $namespaceAttribute = Arr::first($reflectionClass->getAttributes(LodataNamespace::class));


### PR DESCRIPTION
Item 1 (SQLSchema): Replace the old two-step approach (cache raw DBAL Table, re-process columns every request) with a fully cached pipeline. The new buildPropertyDescriptors() stores a serializable array of type names, nullability, and default values. discoverProperties() hydrates these into OData DeclaredProperty objects without touching the database again on cache hits. Maintains compatibility with DBAL 4.x DefaultExpression changes.

Item 5 (Operation): Add an early-exit in Operation::discover() that checks for any LodataOperation attributes before doing the full per-method reflection scan. Models without operations (the common case) return immediately.