### PR TITLE
Support key-as-segment for navigation properties (#299)

### DIFF
--- a/src/PathSegment/Key.php
+++ b/src/PathSegment/Key.php
@@ -25,6 +25,13 @@ class Key implements PipeInterface
         ?string $nextSegment,
         ?PipeInterface $argument
     ): ?PipeInterface {
+        // A navigation property that resolves to a collection arrives here wrapped in a
+        // PropertyValue (e.g. People('id')/Trips/0). Unwrap it so a following key segment
+        // selects a single related entity, mirroring the People('id')/Trips(0) form.
+        if ($argument instanceof PropertyValue && $argument->getValue() instanceof EntitySet) {
+            $argument = $argument->getValue();
+        }
+
         if (!$argument instanceof EntitySet) {
             throw new PathNotHandledException();
         }

--- a/tests/Navigation/Navigation.php
+++ b/tests/Navigation/Navigation.php
@@ -630,4 +630,50 @@ abstract class Navigation extends TestCase
             $this->urlToReq($response->passengers[0]->{'MyPets@navigationLink'})
         );
     }
+
+    public function test_read_navigation_property_entity()
+    {
+        $this->assertJsonResponseSnapshot(
+            (new Request)
+                ->path($this->flightEntitySetPath.'(1)/passengers(3)')
+        );
+    }
+
+    public function test_read_navigation_property_entity_key_as_segment()
+    {
+        $this->assertJsonResponseSnapshot(
+            (new Request)
+                ->path($this->flightEntitySetPath.'/1/passengers/3')
+        );
+    }
+
+    public function test_update_navigation_property_entity_key_as_segment()
+    {
+        $this->assertJsonResponseSnapshot(
+            (new Request)
+                ->patch()
+                ->path($this->flightEntitySetPath.'/1/passengers/3')
+                ->body([
+                    'name' => 'Renamed Passenger',
+                ])
+        );
+    }
+
+    public function test_delete_navigation_property_entity()
+    {
+        $this->assertNoContent(
+            (new Request)
+                ->delete()
+                ->path($this->flightEntitySetPath.'(1)/passengers(3)')
+        );
+    }
+
+    public function test_delete_navigation_property_entity_key_as_segment()
+    {
+        $this->assertNoContent(
+            (new Request)
+                ->delete()
+                ->path($this->flightEntitySetPath.'/1/passengers/3')
+        );
+    }
 }

--- a/tests/__snapshots__/Navigation/EloquentTest__test_delete_navigation_property_entity__1.txt
+++ b/tests/__snapshots__/Navigation/EloquentTest__test_delete_navigation_property_entity__1.txt
@@ -1,0 +1,23 @@
+@@ @@
+             "emails": null
+         },
+         {
+-            "id": 3,
+-            "flight_id": 1,
+-            "name": "Gamma",
+-            "dob": "2002-03-03 06:06:06",
+-            "age": 2,
+-            "chips": true,
+-            "dq": "2002-03-03",
+-            "in_role": 347561,
+-            "open_time": "07:07:07",
+-            "colour": 4,
+-            "sock_colours": 7,
+-            "emails": [
+-                "gamma@example.com"
+-            ]
+-        },
+-        {
+             "id": 4,
+             "flight_id": null,
+             "name": "Delta",

--- a/tests/__snapshots__/Navigation/EloquentTest__test_delete_navigation_property_entity_key_as_segment__1.txt
+++ b/tests/__snapshots__/Navigation/EloquentTest__test_delete_navigation_property_entity_key_as_segment__1.txt
@@ -1,0 +1,23 @@
+@@ @@
+             "emails": null
+         },
+         {
+-            "id": 3,
+-            "flight_id": 1,
+-            "name": "Gamma",
+-            "dob": "2002-03-03 06:06:06",
+-            "age": 2,
+-            "chips": true,
+-            "dq": "2002-03-03",
+-            "in_role": 347561,
+-            "open_time": "07:07:07",
+-            "colour": 4,
+-            "sock_colours": 7,
+-            "emails": [
+-                "gamma@example.com"
+-            ]
+-        },
+-        {
+             "id": 4,
+             "flight_id": null,
+             "name": "Delta",

--- a/tests/__snapshots__/Navigation/EloquentTest__test_read_navigation_property_entity__1.json
+++ b/tests/__snapshots__/Navigation/EloquentTest__test_read_navigation_property_entity__1.json
@@ -1,0 +1,17 @@
+{
+    "@context": "http://localhost/odata/$metadata#Passengers/$entity",
+    "id": 3,
+    "flight_id": 1,
+    "name": "Gamma",
+    "dob": "2002-03-03T06:06:06+00:00",
+    "age": 2,
+    "chips": true,
+    "dq": "2002-03-03",
+    "in_role": "P4DT32M41S",
+    "open_time": "07:07:07.000000",
+    "colour": "Blue",
+    "sock_colours": "Red,Green,Blue",
+    "emails": [
+        "gamma@example.com"
+    ]
+}

--- a/tests/__snapshots__/Navigation/EloquentTest__test_read_navigation_property_entity_key_as_segment__1.json
+++ b/tests/__snapshots__/Navigation/EloquentTest__test_read_navigation_property_entity_key_as_segment__1.json
@@ -1,0 +1,17 @@
+{
+    "@context": "http://localhost/odata/$metadata#Passengers/$entity",
+    "id": 3,
+    "flight_id": 1,
+    "name": "Gamma",
+    "dob": "2002-03-03T06:06:06+00:00",
+    "age": 2,
+    "chips": true,
+    "dq": "2002-03-03",
+    "in_role": "P4DT32M41S",
+    "open_time": "07:07:07.000000",
+    "colour": "Blue",
+    "sock_colours": "Red,Green,Blue",
+    "emails": [
+        "gamma@example.com"
+    ]
+}

--- a/tests/__snapshots__/Navigation/EloquentTest__test_update_navigation_property_entity_key_as_segment__1.json
+++ b/tests/__snapshots__/Navigation/EloquentTest__test_update_navigation_property_entity_key_as_segment__1.json
@@ -1,0 +1,17 @@
+{
+    "@context": "http://localhost/odata/$metadata#Passengers/$entity",
+    "id": 3,
+    "flight_id": 1,
+    "name": "Renamed Passenger",
+    "dob": "2002-03-03T06:06:06+00:00",
+    "age": 2,
+    "chips": true,
+    "dq": "2002-03-03",
+    "in_role": "P4DT32M41S",
+    "open_time": "07:07:07.000000",
+    "colour": "Blue",
+    "sock_colours": "Red,Green,Blue",
+    "emails": [
+        "gamma@example.com"
+    ]
+}

--- a/tests/__snapshots__/Navigation/EloquentTest__test_update_navigation_property_entity_key_as_segment__2.txt
+++ b/tests/__snapshots__/Navigation/EloquentTest__test_update_navigation_property_entity_key_as_segment__2.txt
@@ -1,0 +1,9 @@
+@@ @@
+         {
+             "id": 3,
+             "flight_id": 1,
+-            "name": "Gamma",
++            "name": "Renamed Passenger",
+             "dob": "2002-03-03 06:06:06",
+             "age": 2,
+             "chips": true,

--- a/tests/__snapshots__/Navigation/SQLTest__test_delete_navigation_property_entity__1.txt
+++ b/tests/__snapshots__/Navigation/SQLTest__test_delete_navigation_property_entity__1.txt
@@ -1,0 +1,23 @@
+@@ @@
+             "emails": null
+         },
+         {
+-            "id": 3,
+-            "flight_id": 1,
+-            "name": "Gamma",
+-            "dob": "2002-03-03 06:06:06",
+-            "age": 2,
+-            "chips": true,
+-            "dq": "2002-03-03",
+-            "in_role": 347561,
+-            "open_time": "07:07:07",
+-            "colour": 4,
+-            "sock_colours": 7,
+-            "emails": [
+-                "gamma@example.com"
+-            ]
+-        },
+-        {
+             "id": 4,
+             "flight_id": null,
+             "name": "Delta",

--- a/tests/__snapshots__/Navigation/SQLTest__test_delete_navigation_property_entity_key_as_segment__1.txt
+++ b/tests/__snapshots__/Navigation/SQLTest__test_delete_navigation_property_entity_key_as_segment__1.txt
@@ -1,0 +1,23 @@
+@@ @@
+             "emails": null
+         },
+         {
+-            "id": 3,
+-            "flight_id": 1,
+-            "name": "Gamma",
+-            "dob": "2002-03-03 06:06:06",
+-            "age": 2,
+-            "chips": true,
+-            "dq": "2002-03-03",
+-            "in_role": 347561,
+-            "open_time": "07:07:07",
+-            "colour": 4,
+-            "sock_colours": 7,
+-            "emails": [
+-                "gamma@example.com"
+-            ]
+-        },
+-        {
+             "id": 4,
+             "flight_id": null,
+             "name": "Delta",

--- a/tests/__snapshots__/Navigation/SQLTest__test_read_navigation_property_entity__1.json
+++ b/tests/__snapshots__/Navigation/SQLTest__test_read_navigation_property_entity__1.json
@@ -1,0 +1,17 @@
+{
+    "@context": "http://localhost/odata/$metadata#passengers/$entity",
+    "id": 3,
+    "name": "Gamma",
+    "age": 2,
+    "dob": "2002-03-03T06:06:06+00:00",
+    "chips": true,
+    "dq": "2002-03-03",
+    "in_role": "P4DT32M41S",
+    "open_time": "07:07:07.000000",
+    "flight_id": 1,
+    "colour": "Blue",
+    "sock_colours": "Red,Green,Blue",
+    "emails": [
+        "gamma@example.com"
+    ]
+}

--- a/tests/__snapshots__/Navigation/SQLTest__test_read_navigation_property_entity_key_as_segment__1.json
+++ b/tests/__snapshots__/Navigation/SQLTest__test_read_navigation_property_entity_key_as_segment__1.json
@@ -1,0 +1,17 @@
+{
+    "@context": "http://localhost/odata/$metadata#passengers/$entity",
+    "id": 3,
+    "name": "Gamma",
+    "age": 2,
+    "dob": "2002-03-03T06:06:06+00:00",
+    "chips": true,
+    "dq": "2002-03-03",
+    "in_role": "P4DT32M41S",
+    "open_time": "07:07:07.000000",
+    "flight_id": 1,
+    "colour": "Blue",
+    "sock_colours": "Red,Green,Blue",
+    "emails": [
+        "gamma@example.com"
+    ]
+}

--- a/tests/__snapshots__/Navigation/SQLTest__test_update_navigation_property_entity_key_as_segment__1.json
+++ b/tests/__snapshots__/Navigation/SQLTest__test_update_navigation_property_entity_key_as_segment__1.json
@@ -1,0 +1,17 @@
+{
+    "@context": "http://localhost/odata/$metadata#passengers/$entity",
+    "id": 3,
+    "name": "Renamed Passenger",
+    "age": 2,
+    "dob": "2002-03-03T06:06:06+00:00",
+    "chips": true,
+    "dq": "2002-03-03",
+    "in_role": "P4DT32M41S",
+    "open_time": "07:07:07.000000",
+    "flight_id": 1,
+    "colour": "Blue",
+    "sock_colours": "Red,Green,Blue",
+    "emails": [
+        "gamma@example.com"
+    ]
+}

--- a/tests/__snapshots__/Navigation/SQLTest__test_update_navigation_property_entity_key_as_segment__2.txt
+++ b/tests/__snapshots__/Navigation/SQLTest__test_update_navigation_property_entity_key_as_segment__2.txt
@@ -1,0 +1,9 @@
+@@ @@
+         {
+             "id": 3,
+             "flight_id": 1,
+-            "name": "Gamma",
++            "name": "Renamed Passenger",
+             "dob": "2002-03-03 06:06:06",
+             "age": 2,
+             "chips": true,


### PR DESCRIPTION
Deleting or otherwise operating on a nested child entity via the key-as-segment URL form (e.g. /Flights/1/passengers/3) returned 404 because PathSegment\Key only accepted a raw EntitySet. A navigation property that resolves to a collection arrives wrapped in a PropertyValue, so the trailing key segment was never handled.

Unwrap a PropertyValue whose value is an EntitySet so a following key segment selects a single related entity, mirroring the already-working parenthesised form (/Flights(1)/passengers(3)).

Adds regression tests (Eloquent + SQL drivers) covering GET, PATCH and DELETE of a nested entity via both the parenthesised and key-as-segment URL forms.