### PR TITLE
Clone singletons per-request for Octane safety (#870)

### DIFF
--- a/doc/getting-started/octane.md
+++ b/doc/getting-started/octane.md
@@ -6,7 +6,13 @@ and [Roadrunner](https://roadrunner.dev) configurations.
 The Lodata model is a [singleton](https://laravel.com/docs/8.x/container#binding-a-singleton) in the Laravel
 service container. All requests use the same model, which allows the model to be dynamically updated at runtime without
 requiring a server restart. Lodata does not mutate any internal data structures during the request cycle, making it safe
-and extremely fast for multiple concurrent requests.
+and extremely fast for multiple concurrent requests. Resources resolved while processing a request (entity sets,
+singletons and operations) are cloned before any request-scoped state is attached to them, so the shared model
+instance is never modified by a request.
+
+Because the model is resolved once and kept resident in memory, the cost of [discovery](/getting-started/README.md#step-2-discovery)
+is paid a single time when an Octane worker boots rather than on every request. This makes Octane an effective way to
+remove discovery overhead from the request path for applications that discover a large number of models.
 
 Note that Roadrunner [does not currently](https://github.com/spiral/roadrunner/issues/2) support [streaming responses](/internals/streaming-json.md)
 so all output will buffer in memory before being sent to the client. Swoole responses will stream correctly, so this is

--- a/src/ComplexValue.php
+++ b/src/ComplexValue.php
@@ -63,6 +63,24 @@ class ComplexValue implements ArrayAccess, Arrayable, JsonInterface, ReferenceIn
     }
 
     /**
+     * Clone this complex value instance
+     *
+     * The property values and metadata are request-scoped mutable state (the property
+     * value collection maintains an internal iterator position during emission, and the
+     * metadata container is rebuilt per request). When a shared instance such as a
+     * Singleton is reused across requests - for example under Laravel Octane - these must
+     * not be shared between the original and the clone.
+     */
+    public function __clone()
+    {
+        assert(!$this->transaction);
+
+        $this->cloned = true;
+        $this->propertyValues = clone $this->propertyValues;
+        $this->metadata = null;
+    }
+
+    /**
      * Set the parent property value of this complex value
      * @param  PropertyValue  $parent  Parent property
      * @return $this

--- a/src/Singleton.php
+++ b/src/Singleton.php
@@ -109,6 +109,10 @@ class Singleton extends Entity implements ServiceInterface, IdentifierInterface,
             throw new PathNotHandledException();
         }
 
+        // Operate on a clone so the request cycle does not mutate the shared model
+        // instance, which is reused across requests under Laravel Octane.
+        $singleton = clone $singleton;
+
         Gate::read($singleton, $transaction)->ensure();
 
         return $singleton;

--- a/tests/Octane/OctaneTest.php
+++ b/tests/Octane/OctaneTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Flat3\Lodata\Tests\Octane;
+
+use Flat3\Lodata\DeclaredProperty;
+use Flat3\Lodata\EntityType;
+use Flat3\Lodata\Facades\Lodata;
+use Flat3\Lodata\Helper\PropertyValue;
+use Flat3\Lodata\Singleton;
+use Flat3\Lodata\Tests\Helpers\Request;
+use Flat3\Lodata\Tests\TestCase;
+use Flat3\Lodata\Type;
+use ReflectionProperty;
+
+/**
+ * Under Laravel Octane the application - and therefore the Lodata model singleton and
+ * every resource it holds - stays resident in memory and is reused across many requests.
+ * The request cycle must therefore never mutate a shared model resource, otherwise state
+ * leaks between requests. These tests exercise the request cycle against shared resources
+ * and assert that the shared instances are left untouched.
+ */
+class OctaneTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $type = new EntityType('a');
+        $type->addProperty(new DeclaredProperty('b', Type::string()));
+
+        // A nullable property that is not set on the singleton. Emitting the singleton
+        // adds an explicit null value for it, which would accumulate on a shared instance.
+        $type->addProperty(new DeclaredProperty('c', Type::string()));
+        Lodata::add($type);
+
+        $singleton = new Singleton('stest', $type);
+        $pv = new PropertyValue();
+        $pv->setProperty($type->getProperty('b'));
+        $pv->setValue(new Type\String_('value'));
+        $singleton->addPropertyValue($pv);
+        Lodata::add($singleton);
+    }
+
+    /**
+     * Read a protected property from an object instance.
+     * @param  object  $object
+     * @param  string  $property
+     * @return mixed
+     */
+    private function getProperty($object, string $property)
+    {
+        $reflection = new ReflectionProperty($object, $property);
+        $reflection->setAccessible(true);
+
+        return $reflection->getValue($object);
+    }
+
+    public function test_reading_a_singleton_does_not_mutate_the_shared_instance()
+    {
+        /** @var Singleton $shared */
+        $shared = Lodata::getSingleton('stest');
+
+        $initialPropertyCount = $shared->getPropertyValues()->count();
+
+        // Simulate Octane reusing the same in-memory model across multiple requests.
+        for ($request = 0; $request < 3; $request++) {
+            $response = $this->req(
+                (new Request)
+                    ->path('stest')
+            );
+
+            $this->assertEquals(200, $response->getStatusCode());
+            $this->assertStringContainsString('"b":"value"', $response->streamedContent());
+        }
+
+        // The shared singleton retrieved from the model must be byte-for-byte the same
+        // object we started with, with none of the per-request state attached to it.
+        $this->assertSame($shared, Lodata::getSingleton('stest'));
+        $this->assertNull($this->getProperty($shared, 'metadata'), 'Per-request metadata leaked onto the shared singleton');
+        $this->assertNull($this->getProperty($shared, 'transaction'), 'Per-request transaction leaked onto the shared singleton');
+        $this->assertFalse($this->getProperty($shared, 'cloned'), 'The shared singleton was marked as cloned');
+        $this->assertEquals(
+            $initialPropertyCount,
+            $shared->getPropertyValues()->count(),
+            'Property values accumulated on the shared singleton across requests'
+        );
+    }
+
+    public function test_cloning_a_complex_value_isolates_property_values()
+    {
+        /** @var Singleton $shared */
+        $shared = Lodata::getSingleton('stest');
+
+        $clone = clone $shared;
+
+        $pv = new PropertyValue();
+        $pv->setProperty($shared->getType()->getProperty('c'));
+        $pv->setValue(new Type\String_('clone-only'));
+        $clone->addPropertyValue($pv);
+
+        $this->assertCount(2, $clone->getPropertyValues());
+        $this->assertCount(1, $shared->getPropertyValues());
+        $this->assertNotSame(
+            $this->getProperty($shared, 'propertyValues'),
+            $this->getProperty($clone, 'propertyValues'),
+            'Clone shares the property value collection with the original'
+        );
+    }
+}


### PR DESCRIPTION
The Lodata model is a container singleton, so under Laravel Octane it and every resource it holds stay resident in memory and are reused across requests. Entity sets and operations were already cloned before any request-scoped state was attached to them, but Singleton::pipe() returned the shared instance directly. During the request cycle Entity::get() and emitJson() then mutated that shared object (setting metadata, advancing the propertyValues iterator, and appending null/generated/computed/navigation property values), leaking and accumulating state across requests.

Clone the singleton in Singleton::pipe(), and give ComplexValue a __clone() that deep-clones the property value collection and resets the metadata so the existing per-request mutations land on the clone rather than the shared model instance.

Adds a regression test that reuses the singleton model across multiple simulated requests and asserts the shared instance is left untouched.