### PR TITLE
Don't cast enum type with string backed enums.

### DIFF
--- a/src/Drivers/EloquentEntitySet.php
+++ b/src/Drivers/EloquentEntitySet.php
@@ -71,6 +71,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use ReflectionAttribute;
 use ReflectionClass;
+use ReflectionEnum;
 use ReflectionException;
 use ReflectionMethod;
 use Staudenmeir\EloquentJsonRelations\Relations\BelongsToJson;
@@ -783,6 +784,10 @@ class EloquentEntitySet extends EntitySet implements CountInterface, CreateInter
                     break;
 
                 case EnumerationType::isEnum($cast):
+                    if ((new \ReflectionEnum($cast))->getBackingType() == 'string') {
+                        $type = Type::string();
+                        break;
+                    }
                     $type = EnumerationType::discover($cast);
                     break;
 


### PR DESCRIPTION
Was just trying this project out with a laravel application, and it seems to work pretty well but it broke discovering most of my models as I often use string backed enums. 

It seems (via #572) the OData spec doesn't allow for string backed enums so there is no way to support this - so I propose this change to set string enums to the string type by default rather then breaking by forcing into an enum that expects an int.

I couldn't work out the tests, but it works on my laravel application. ReflectionEnum is only in ^8.1 but the EnumerationType::isEnum checks the php version already so it shouldn't hit that on lower versions.